### PR TITLE
initHighlightingOnLoad() to highlightAll()

### DIFF
--- a/_includes/externals/styling.html
+++ b/_includes/externals/styling.html
@@ -9,7 +9,7 @@
 <!-- Highlight.js -->
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/styles/default.min.css">
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
+<script>hljs.highlightAll();</script>
 
 <!-- Main assets -->
 <link rel="icon" type="image/jpeg" href="{{ site.url }}/favicon.png"/>


### PR DESCRIPTION
initHighlightingOnLoad() deprecated as of 10.6.0. Use highlightAll() now.